### PR TITLE
Introduce temporary features for hierarchy children

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.47.5
+ - enh: allow temporary features for hierarchy children (#123)
 0.47.4
  - enh: allow pathlib.Path objects in cli.get_command_log custom dicts
 0.47.3

--- a/dclab/rtdc_dataset/feat_temp.py
+++ b/dclab/rtdc_dataset/feat_temp.py
@@ -61,7 +61,9 @@ def set_temporary_feature(rtdc_ds, feature, data):
     rtdc_ds: dclab.RTDCBase
         Dataset for which to set the feature. Note that the
         length of the feature `data` must match the number of events
-        in `rtdc_ds`.
+        in `rtdc_ds`. If the dataset is a hierarchy child, the data will also
+        be set in the parent dataset, but only for those events that are part
+        of the child. All non-child events become np.nan.
     feature: str
         Feature name
     data: np.ndarray

--- a/dclab/rtdc_dataset/feat_temp.py
+++ b/dclab/rtdc_dataset/feat_temp.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from ..definitions import feat_logic
+
 from .fmt_hierarchy import RTDC_Hierarchy, map_indices_child2root
 
 
@@ -63,7 +64,8 @@ def set_temporary_feature(rtdc_ds, feature, data):
         length of the feature `data` must match the number of events
         in `rtdc_ds`. If the dataset is a hierarchy child, the data will also
         be set in the parent dataset, but only for those events that are part
-        of the child. All non-child events become np.nan.
+        of the child. For all events in the parent dataset that are not part
+        of the child dataset, the temporary feature is set to np.nan.
     feature: str
         Feature name
     data: np.ndarray
@@ -82,7 +84,8 @@ def set_temporary_feature(rtdc_ds, feature, data):
         root_feat_data = np.empty((len(root_parent)))
         root_feat_data[:] = np.nan
         root_feat_data[root_ids] = data
+        set_temporary_feature(root_parent, feature, root_feat_data)
+        rtdc_ds.rejuvenate()
+    else:
         feat_logic.check_feature_shape(feature, data)
-        root_parent._usertemp[feature] = root_feat_data
-    feat_logic.check_feature_shape(feature, data)
-    rtdc_ds._usertemp[feature] = data
+        rtdc_ds._usertemp[feature] = data

--- a/tests/test_rtdc_feat_temp.py
+++ b/tests/test_rtdc_feat_temp.py
@@ -160,6 +160,8 @@ def test_hierarchy_children_grandchildren():
                                       [0, 1, 2, 3, 4, 5])
         np.testing.assert_array_equal(ds["my_special_feature"][:],
                                       [0, np.nan, 1, 2, 3, 4, 5])
+        np.testing.assert_array_equal(grandchild["my_special_feature"],
+                                      [0, 1, 2, 3, 4])
         assert "my_special_feature" in grandchild.features
         assert len(grandchild) == 5
         dclab.register_temporary_feature("feature_six")


### PR DESCRIPTION
This PR aims to support temporary features for hierarchy children. It basically means that, once a user sets temporary features for a child dataset, the root parent is determined and the temporary feature data is set for all those events that are also in the child. All events that are not in the child will be assigned NaN values.

I updated the tests accordingly. I didn't find anything in the docs that said hierarchy children are not supported, and I updated the docstring of the function `set_temporary_feature`.

closes #123 