### PR TITLE
Add QPI features to dclab definitions

### DIFF
--- a/dclab/definitions/feat_const.py
+++ b/dclab/definitions/feat_const.py
@@ -109,6 +109,10 @@ FEATURES_SCALAR = [
     # Fun fact: If we had decided to compute it from the convex contour,
     # then we would have close to none pixelation effects ¯\_(ツ)_/¯.
     ["volume", "Volume [µm³]"],
+    # QPI features computed from holographic data
+    ["qpi_dm", "Dry Mass [pg]"],
+    ["qpi_ri", "Refractive Index"],
+    ["qpi_pha_int", "Integrated Phase [rad]"],
 ]
 # Add userdef features
 for _i in range(10):
@@ -126,6 +130,11 @@ FEATURES_NON_SCALAR = [
     ["mask", "Binary mask labeling the event in the image"],
     # See FLUOR_TRACES for valid keys
     ["trace", "Dictionary of fluorescence traces"],
+    # QPI features computed from holographic data
+    ["qpi_oah", "Off axis hologram"],
+    ["qpi_oah_bg", "Off axis hologram background image"],
+    ["qpi_pha", "Hologram phase image [rad]"],
+    ["qpi_amp", "Hologram amplitude image"],
 ]
 
 #: List of fluorescence traces


### PR DESCRIPTION
As described in [bullet point 1 here](https://github.com/DC-analysis/dclab/issues/192#issuecomment-1525532468), the QPI features must be added to the feature definitions.

## To-do
- [ ] Decide whether non-scalar qpi images should have their own special const list
- [ ] Add qpi features to all parts of the `dclab/definitions`.
- [ ] ci/cd passing
- [ ] update changelog
