### PR TITLE
Issue 214 lru cache mem leak

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 0.54.3
- - ref: replace lru_cache on instance methods with cache attributes
+ - fix: replace lru_cache on instance methods to fix memory leak (#214)
  - fix: implement `__contains__` for DCOR logs and tables
  - enh: add requests timeout for DCOR data
  - enh: more caching of event size and shape for HDF5 format

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.54.3
+ - ref: replace lru_cache on instance methods with cache attributes
  - fix: implement `__contains__` for DCOR logs and tables
  - enh: add requests timeout for DCOR data
  - enh: more caching of event size and shape for HDF5 format

--- a/dclab/rtdc_dataset/core.py
+++ b/dclab/rtdc_dataset/core.py
@@ -38,6 +38,8 @@ class RTDCBase(abc.ABC):
         #: Dataset format (derived from class name)
         self.format = self.__class__.__name__.split("_")[-1].lower()
 
+        # Cache attribute used for __len__()-function
+        self._length = None
         self._polygon_filter_ids = []
         # Events have the feature name as keys and contain nD ndarrays.
         self._events = {}
@@ -135,6 +137,13 @@ class RTDCBase(abc.ABC):
             yield col
 
     def __len__(self):
+        if self._length is None:
+            self._length = self._get_length()
+        return self._length
+
+    def _get_length(self):
+        """ implement here what is currently in __len__ + caching attribute (_length) """
+        """ and child-classes can override """
         # Try to get length from metadata.
         length = self.config["experiment"].get("event count")
         if length:
@@ -148,6 +157,10 @@ class RTDCBase(abc.ABC):
                 return length
         else:
             raise ValueError(f"Could not determine size of dataset '{self}'.")
+
+    @abstractmethod
+    def my_function(self):
+        pass
 
     def __repr__(self):
         repre = "<{} '{}' at {}".format(self.__class__.__name__,

--- a/dclab/rtdc_dataset/core.py
+++ b/dclab/rtdc_dataset/core.py
@@ -142,25 +142,19 @@ class RTDCBase(abc.ABC):
         return self._length
 
     def _get_length(self):
-        """ implement here what is currently in __len__ + caching attribute (_length) """
-        """ and child-classes can override """
         # Try to get length from metadata.
         length = self.config["experiment"].get("event count")
-        if length:
+        if length is None:
             return length
         # Try to get the length from the feature sizes
-        keys = list(self._events.keys())
+        keys = list(self._events.keys()) + self.features_basin
         keys.sort()
         for kk in keys:
-            length = len(self._events[kk])
+            length = len(self[kk])
             if length:
                 return length
         else:
             raise ValueError(f"Could not determine size of dataset '{self}'.")
-
-    @abstractmethod
-    def my_function(self):
-        pass
 
     def __repr__(self):
         repre = "<{} '{}' at {}".format(self.__class__.__name__,

--- a/dclab/rtdc_dataset/core.py
+++ b/dclab/rtdc_dataset/core.py
@@ -144,10 +144,10 @@ class RTDCBase(abc.ABC):
     def _get_length(self):
         # Try to get length from metadata.
         length = self.config["experiment"].get("event count")
-        if length is None:
+        if length is not None:
             return length
         # Try to get the length from the feature sizes
-        keys = list(self._events.keys()) + self.features_basin
+        keys = list(self._events.keys()) or self.features_basin
         keys.sort()
         for kk in keys:
             length = len(self[kk])

--- a/dclab/rtdc_dataset/fmt_dcor/logs.py
+++ b/dclab/rtdc_dataset/fmt_dcor/logs.py
@@ -1,9 +1,7 @@
-import functools
-
-
 class DCORLogs:
     def __init__(self, api):
         self.api = api
+        self._logs_cache = None
 
     def __contains__(self, key):
         return key in self.keys()
@@ -18,6 +16,7 @@ class DCORLogs:
         return self._logs.keys()
 
     @property
-    @functools.lru_cache()
     def _logs(self):
-        return self.api.get(query="logs")
+        if self._logs_cache is None:
+            self._logs_cache = self.api.get(query="logs")
+        return self._logs_cache

--- a/dclab/rtdc_dataset/fmt_dcor/tables.py
+++ b/dclab/rtdc_dataset/fmt_dcor/tables.py
@@ -1,11 +1,10 @@
-import functools
-
 import numpy as np
 
 
 class DCORTables:
     def __init__(self, api):
         self.api = api
+        self._tables_cache = None
 
     def __contains__(self, key):
         return key in self.keys()
@@ -20,17 +19,18 @@ class DCORTables:
         return self._tables.keys()
 
     @property
-    @functools.lru_cache()
     def _tables(self):
-        table_data = self.api.get(query="tables")
-        # assemble the tables
-        tables = {}
-        for key in table_data:
-            columns, data = table_data[key]
-            ds_dt = np.dtype({'names': columns,
-                              'formats': [np.float64] * len(columns)})
-            tab_data = np.asarray(data)
-            rec_arr = np.rec.array(tab_data, dtype=ds_dt)
-            tables[key] = rec_arr
+        if self._tables_cache is None:
+            table_data = self.api.get(query="tables")
+            # assemble the tables
+            tables = {}
+            for key in table_data:
+                columns, data = table_data[key]
+                ds_dt = np.dtype({'names': columns,
+                                  'formats': [np.float64] * len(columns)})
+                tab_data = np.asarray(data)
+                rec_arr = np.rec.array(tab_data, dtype=ds_dt)
+                tables[key] = rec_arr
 
-        return tables
+            self._tables_cache = tables
+        return self._tables_cache

--- a/dclab/rtdc_dataset/fmt_hdf5/base.py
+++ b/dclab/rtdc_dataset/fmt_hdf5/base.py
@@ -1,7 +1,6 @@
 """RT-DC hdf5 format"""
 from __future__ import annotations
 
-import functools
 import json
 import pathlib
 from typing import Any, BinaryIO, Dict

--- a/dclab/rtdc_dataset/fmt_hdf5/base.py
+++ b/dclab/rtdc_dataset/fmt_hdf5/base.py
@@ -118,14 +118,6 @@ class RTDC_HDF5(RTDCBase):
                 if b._ds is not None:
                     b._ds.close()
 
-    @functools.lru_cache()
-    def __len__(self):
-        ec = self.h5file.get("experiment:event count")
-        if ec is not None:
-            return ec
-        else:
-            return super(RTDC_HDF5, self).__len__()
-
     @property
     def _h5(self):
         warnings.warn("Access to the underlying HDF5 file is now public. "

--- a/dclab/rtdc_dataset/fmt_hdf5/events.py
+++ b/dclab/rtdc_dataset/fmt_hdf5/events.py
@@ -1,7 +1,6 @@
 """RT-DC hdf5 format"""
 from __future__ import annotations
 
-import functools
 import numbers
 import numpy as np
 
@@ -103,7 +102,8 @@ class H5Events:
         """Whether the stored feature is defective"""
         if feat not in self._defective_features:
             defective = False
-            if feat in feat_defect.DEFECTIVE_FEATURES and feat in self._features:
+            if (feat in feat_defect.DEFECTIVE_FEATURES
+                    and feat in self._features):
                 # feature exists in the HDF5 file
                 # workaround machinery for sorting out defective features
                 defective = feat_defect.DEFECTIVE_FEATURES[feat](self.h5file)

--- a/dclab/rtdc_dataset/fmt_hdf5/logs.py
+++ b/dclab/rtdc_dataset/fmt_hdf5/logs.py
@@ -1,6 +1,3 @@
-import functools
-
-
 class H5Logs:
     def __init__(self, h5):
         self.h5file = h5

--- a/dclab/rtdc_dataset/fmt_hdf5/logs.py
+++ b/dclab/rtdc_dataset/fmt_hdf5/logs.py
@@ -4,6 +4,7 @@ import functools
 class H5Logs:
     def __init__(self, h5):
         self.h5file = h5
+        self._cache_keys = None
 
     def __getitem__(self, key):
         if key in self.keys():
@@ -24,11 +25,12 @@ class H5Logs:
     def __len__(self):
         return len(self.keys())
 
-    @functools.lru_cache()
     def keys(self):
-        names = []
-        if "logs" in self.h5file:
-            for key in self.h5file["logs"]:
-                if self.h5file["logs"][key].size:
-                    names.append(key)
-        return names
+        if self._cache_keys is None:
+            names = []
+            if "logs" in self.h5file:
+                for key in self.h5file["logs"]:
+                    if self.h5file["logs"][key].size:
+                        names.append(key)
+            self._cache_keys = names
+        return self._cache_keys

--- a/dclab/rtdc_dataset/fmt_hdf5/tables.py
+++ b/dclab/rtdc_dataset/fmt_hdf5/tables.py
@@ -4,6 +4,7 @@ import functools
 class H5Tables:
     def __init__(self, h5):
         self.h5file = h5
+        self._cache_keys = None
 
     def __getitem__(self, key):
         if key in self.keys():
@@ -21,11 +22,12 @@ class H5Tables:
     def __len__(self):
         return len(self.keys())
 
-    @functools.lru_cache()
     def keys(self):
-        names = []
-        if "tables" in self.h5file:
-            for key in self.h5file["tables"]:
-                if self.h5file["tables"][key].size:
-                    names.append(key)
-        return names
+        if self._cache_keys is None:
+            names = []
+            if "tables" in self.h5file:
+                for key in self.h5file["tables"]:
+                    if self.h5file["tables"][key].size:
+                        names.append(key)
+            self._cache_keys = names
+        return self._cache_keys

--- a/dclab/rtdc_dataset/fmt_hdf5/tables.py
+++ b/dclab/rtdc_dataset/fmt_hdf5/tables.py
@@ -1,6 +1,3 @@
-import functools
-
-
 class H5Tables:
     def __init__(self, h5):
         self.h5file = h5

--- a/dclab/rtdc_dataset/fmt_hierarchy.py
+++ b/dclab/rtdc_dataset/fmt_hierarchy.py
@@ -310,6 +310,8 @@ class RTDC_Hierarchy(RTDCBase):
             # This will also populate all event attributes
             self.apply_filter()
 
+        self._length = None
+
     def __contains__(self, key):
         return self.hparent.__contains__(key)
 
@@ -336,9 +338,10 @@ class RTDC_Hierarchy(RTDCBase):
                 + "root parent of this hierarchy child).")
         return data
 
-    @functools.lru_cache()
     def __len__(self):
-        return np.sum(self.hparent.filter.all)
+        if self._length is None:
+            self._length = np.sum(self.hparent.filter.all)
+        return self._length
 
     def _assert_filter(self):
         """Make sure filters exists
@@ -426,7 +429,6 @@ class RTDC_Hierarchy(RTDCBase):
         self.hparent.apply_filter(*args, **kwargs)
 
         # Clear anything that has been cached until now
-#        self.__len__.cache_clear()
         self._length = None
 
         # update event index

--- a/dclab/rtdc_dataset/fmt_hierarchy.py
+++ b/dclab/rtdc_dataset/fmt_hierarchy.py
@@ -426,7 +426,8 @@ class RTDC_Hierarchy(RTDCBase):
         self.hparent.apply_filter(*args, **kwargs)
 
         # Clear anything that has been cached until now
-        self.__len__.cache_clear()
+#        self.__len__.cache_clear()
+        self._length = None
 
         # update event index
         event_count = len(self)

--- a/dclab/rtdc_dataset/fmt_hierarchy.py
+++ b/dclab/rtdc_dataset/fmt_hierarchy.py
@@ -1,6 +1,5 @@
 """RT-DC hierarchy format"""
 import collections
-import functools
 
 import numpy as np
 

--- a/dclab/rtdc_dataset/fmt_tdms/event_contour.py
+++ b/dclab/rtdc_dataset/fmt_tdms/event_contour.py
@@ -58,6 +58,7 @@ class ContourColumn(object):
                 self.pxfeat[key] = rtdc_dataset[key] / px_size
 
         self.event_offset = 0
+        self._length = None
 
     def __getitem__(self, idx):
         if not isinstance(idx, numbers.Integral):
@@ -127,14 +128,15 @@ class ContourColumn(object):
             )
         return cdata
 
-    @functools.lru_cache(maxsize=1)
     def __len__(self):
-        length = len(self._contour_data)
-        if length:
-            if not self._initialized:
-                self.determine_offset()
-            length += self.event_offset
-        return length
+        if self._length is None:
+            length = len(self._contour_data)
+            if length:
+                if not self._initialized:
+                    self.determine_offset()
+                length += self.event_offset
+            self._length = length
+        return self._length
 
     @property
     def shape(self):
@@ -209,6 +211,7 @@ class ContourData(object):
         """
         self._initialized = False
         self.filename = fname
+        self._length = None
 
     def __getitem__(self, idx):
         cont = self.data[idx]
@@ -225,9 +228,10 @@ class ContourData(object):
             data = np.fromstring(cont, sep=",", dtype=np.uint16).reshape(-1, 2)
             return data
 
-    @functools.lru_cache(maxsize=1)
     def __len__(self):
-        return len(self.data)
+        if self._length is None:
+            self._length = len(self.data)
+        return self._length
 
     def _index_file(self):
         """Open and index the contour file

--- a/dclab/rtdc_dataset/fmt_tdms/event_contour.py
+++ b/dclab/rtdc_dataset/fmt_tdms/event_contour.py
@@ -1,5 +1,4 @@
 """Class for efficiently handling contour data"""
-import functools
 import numbers
 import sys
 import warnings

--- a/dclab/rtdc_dataset/fmt_tdms/event_image.py
+++ b/dclab/rtdc_dataset/fmt_tdms/event_image.py
@@ -34,6 +34,7 @@ class ImageColumn(object):
         conf = rtdc_dataset.config
         self.event_offset = int(conf["fmt_tdms"]["video frame offset"])
         self.video_file = fname
+        self._shape = None
 
     def __getitem__(self, idx):
         if not isinstance(idx, numbers.Integral):
@@ -79,10 +80,11 @@ class ImageColumn(object):
         return cdata
 
     @property
-    @functools.lru_cache()
     def shape(self):
-        f0 = self._image_data[0].shape
-        return len(self), f0[0], f0[1]
+        if self._shape is None:
+            f0 = self._image_data[0].shape
+            self._shape = len(self), f0[0], f0[1]
+        return self._shape
 
     @staticmethod
     def find_video_file(rtdc_dataset):

--- a/dclab/rtdc_dataset/fmt_tdms/event_image.py
+++ b/dclab/rtdc_dataset/fmt_tdms/event_image.py
@@ -1,7 +1,6 @@
 """
 Class for efficiently handling image/video data
 """
-import functools
 import numbers
 import pathlib
 import sys

--- a/dclab/rtdc_dataset/fmt_tdms/event_mask.py
+++ b/dclab/rtdc_dataset/fmt_tdms/event_mask.py
@@ -1,5 +1,4 @@
 """Class for on-the-fly conversion of contours to masks"""
-import functools
 import numbers
 
 import numpy as np


### PR DESCRIPTION
In this MR we refactor all `functools.lru_cache` decorators on instance methods, since they introduce memory-leak.

Currently the only class that still contains `lru_cache`-decorators for instance methods is `DCORTraceItem` in `dclab.rtdc_dataset/fmt_dcor/events.py`. There are going to be future refactoring steps that will remove these.
