### PR TITLE
Enable RTDC copier to accept list of features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.57.2
+ - enh: allow to specify list of features for data copier
 0.57.1
  - fix: RTDCWriter.rectify_metadata fails when image feature is empty
  - fix: handle empty write requests in export.hdf5 and RTDCWriter (#242)

--- a/dclab/rtdc_dataset/copier.py
+++ b/dclab/rtdc_dataset/copier.py
@@ -79,7 +79,7 @@ def rtdc_copy(src_h5file: h5py.Group,
     elif features == "all":
         feature_iter = list(src_h5file["events"])
     elif features == "scalar":
-        feature_iter = [feat for feat in features
+        feature_iter = [feat for feat in src_h5file["events"]
                         if feature_exists(feat, scalar_only=True)]
     elif features == "none":
         feature_iter = []

--- a/tests/test_rtdc_copier.py
+++ b/tests/test_rtdc_copier.py
@@ -113,7 +113,7 @@ def test_copy_tables():
     tab_data = np.zeros((10, len(columns)))
     tab_data[:, 0] = np.arange(10)
     tab_data[:, 1] = 1000
-    tab_data[:, 2] = np.linspace(np.pi, 2*np.pi, 10)
+    tab_data[:, 2] = np.linspace(np.pi, 2 * np.pi, 10)
     rec_arr = np.rec.array(tab_data, dtype=ds_dt)
     # sanity check
     assert np.all(rec_arr["bread"][:].flatten() == np.arange(10))
@@ -140,7 +140,7 @@ def test_copy_tables():
         assert np.all(tab_data["bread"][:].flatten() == np.arange(10))
         assert np.all(tab_data["beer"][:].flatten() == 1000)
         assert np.all(tab_data["chocolate"][:].flatten() == np.linspace(
-            np.pi, 2*np.pi, 10))
+            np.pi, 2 * np.pi, 10))
 
 
 def test_copy_tables_hdf5_issue_3214():
@@ -208,4 +208,25 @@ def test_copy_scalar_features_only():
     # Make sure this worked
     with h5py.File(path_copy) as hc:
         assert "image" not in hc["events"]
+        assert "deform" in hc["events"]
+
+
+def test_copy_specified_feature_list():
+    path = retrieve_data("fmt-hdf5_image-bg_2020.zip")
+    path_copy = path.with_name("test_copy.rtdc")
+
+    # copy
+    with h5py.File(path) as h5, h5py.File(path_copy, "w") as hc:
+        # make sure image data is there
+        assert "image" in h5["events"]
+        assert "area_um" in h5["events"]
+        assert "deform" in h5["events"]
+        rtdc_copy(src_h5file=h5,
+                  dst_h5file=hc,
+                  features=["image", "area_um", "deform"])
+
+    # Make sure this worked
+    with h5py.File(path_copy) as hc:
+        assert "image" in hc["events"]
+        assert "area_um" in hc["events"]
         assert "deform" in hc["events"]

--- a/tests/test_rtdc_copier.py
+++ b/tests/test_rtdc_copier.py
@@ -223,10 +223,10 @@ def test_copy_specified_feature_list():
         assert "deform" in h5["events"]
         rtdc_copy(src_h5file=h5,
                   dst_h5file=hc,
-                  features=["image", "area_um", "deform"])
+                  features=["image", "deform"])
 
     # Make sure this worked
     with h5py.File(path_copy) as hc:
         assert "image" in hc["events"]
-        assert "area_um" in hc["events"]
+        assert "area_um" not in hc["events"]
         assert "deform" in hc["events"]


### PR DESCRIPTION
This pull request is aimed at enabling `dclab.rtdc_dataset.copier` to accept a list of feature strings that can be copied from the source RTDC file to the destination RTDC file.

This allows us to include a CLI option to write a specified list of features as mentioned in #246.