### PR TITLE
check feature list for export for duplicates (#257)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.60.4
+ - fix: check feature list for export for duplicates (#257)
  - docs: a few clarifications on Young's modulus computation
 0.60.3
  - fix: add args and kwargs to all __array__ methods

--- a/dclab/rtdc_dataset/export.py
+++ b/dclab/rtdc_dataset/export.py
@@ -145,6 +145,7 @@ class Export(object):
                 str(path).encode("ascii", "ignore")) +
                 "Please use the `override=True` option.")
         # Check that features are valid
+        features = sorted(list(set(features)))
         for c in features:
             if c not in ds.features_scalar:
                 msg = "Invalid feature name: {}".format(c)
@@ -282,6 +283,7 @@ class Export(object):
         else:
             filter_arr = None
 
+        features = sorted(list(set(features)))
         if not skip_checks and features:
             # check that all features have same length and use the smallest
             # common length
@@ -468,6 +470,7 @@ class Export(object):
         if meta_data is None:
             meta_data = {}
         features = [c.lower() for c in features]
+        features = sorted(list(set(features)))
         path = pathlib.Path(path)
         ds = self.rtdc_ds
         # Make sure that path ends with .tsv

--- a/tests/test_rtdc_export_hdf5.py
+++ b/tests/test_rtdc_export_hdf5.py
@@ -35,6 +35,28 @@ def test_hdf5():
     assert np.allclose(ds2["fl3_width"], ds1["fl3_width"])
 
 
+def test_hdf5_duplicate_feature_for_export():
+    keys = ["area_um", "deform", "time", "frame", "fl3_width"]
+    ddict = example_data_dict(size=127, keys=keys)
+    ds1 = dclab.new_dataset(ddict)
+    ds1.config["experiment"]["sample"] = "test"
+    ds1.config["experiment"]["run index"] = 1
+    ds1.config["imaging"]["frame rate"] = 2000
+
+    edest = tempfile.mkdtemp()
+    f1 = join(edest, "dclab_test_export_hdf5.rtdc")
+    keys.append("area_um")
+    ds1.export.hdf5(f1, keys)
+
+    ds2 = dclab.new_dataset(f1)
+    assert ds1 != ds2
+    assert np.allclose(ds2["area_um"], ds1["area_um"])
+    assert np.allclose(ds2["deform"], ds1["deform"])
+    assert np.allclose(ds2["time"], ds1["time"])
+    assert np.allclose(ds2["frame"], ds1["frame"])
+    assert np.allclose(ds2["fl3_width"], ds1["fl3_width"])
+
+
 def test_hdf5_contour_image_trace():
     n = 65
     keys = ["contour", "image", "trace"]
@@ -495,7 +517,7 @@ def test_hdf5_logs(logs):
 
 def test_hdf5_logs_meta():
     """Test export of export log #251"""
-    keys = ["area_um", "deform", "time", "frame", "fl3_width"]
+    keys = ["area_um", "deform", "fl3_width", "frame", "time"]
     ddict = example_data_dict(size=127, keys=keys)
     ds1 = dclab.new_dataset(ddict)
     ds1.config["experiment"]["sample"] = "test"


### PR DESCRIPTION
I implemented a quick fix for this issue using Python's `set()` method. Since redundant data is always bad, I implemented the fix not only for the `export.hdf5()` method, but also for the functions `export.fcs()` and `export.tsv()`.

I added a test to check that it works for hdf5 files.