### PR TITLE
Deprecate get_contour and use bin_width_doane_div5 in KDE submodule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 0.63.2
- - ref: use bin_width_doane_div5 in kde methods and deprecate get_contour (#153)
+ - ref: deprecate get_contour and use bin_width_doane_div5 in kde submodule
 0.63.1
  - docs: update documentation and code references for kde submodule
  - enh: cache S3 sessions and clients (test suite duration reduced by 30%)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.63.2
+ - ref: use bin_width_doane_div5 in kde methods and deprecate get_contour (#153)
 0.63.1
  - docs: update documentation and code references for kde submodule
  - enh: cache S3 sessions and clients (test suite duration reduced by 30%)

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 
-from .methods import bin_width_doane, get_bad_vals, methods
+from .methods import bin_width_doane_div5, get_bad_vals, methods
 
 
 class KernelDensityEstimator:
@@ -112,6 +112,47 @@ class KernelDensityEstimator:
         X, Y, Z : coordinates
             The kernel density Z evaluated on a rectangular grid (X,Y).
         """
+        warnings.warn("`get_contour` is deprecated; please use "
+                      "`get_raster` instead", DeprecationWarning)
+        return self.get_raster(
+            xax=xax, yax=yax, xacc=xacc, yacc=yacc,
+            kde_type=kde_type, kde_kwargs=kde_kwargs,
+            xscale=xscale, yscale=yscale
+        )
+
+    def get_raster(self, xax="area_um", yax="deform", xacc=None, yacc=None,
+                   kde_type="histogram", kde_kwargs=None, xscale="linear",
+                   yscale="linear"):
+        """Evaluate the kernel density estimate on a grid
+
+        Parameters
+        ----------
+        xax: str
+            Identifier for X axis (e.g. "area_um", "aspect", "deform")
+        yax: str
+            Identifier for Y axis
+        xacc: float
+            Contour accuracy in x direction
+            if set to None, will use :func:`bin_width_doane_div5`
+        yacc: float
+            Contour accuracy in y direction
+            if set to None, will use :func:`bin_width_doane_div5`
+        kde_type: str
+            The KDE method to use
+        kde_kwargs: dict
+            Additional keyword arguments to the KDE method
+        xscale: str
+            If set to "log", take the logarithm of the x-values before
+            computing the KDE. This is useful when data are
+            displayed on a log-scale. Defaults to "linear".
+        yscale: str
+            See `xscale`.
+
+        Returns
+        -------
+        X, Y, Z : coordinates
+            The kernel density Z evaluated on a rectangular grid (X,Y).
+        """
         if kde_kwargs is None:
             kde_kwargs = {}
         xax = xax.lower()
@@ -128,21 +169,21 @@ class KernelDensityEstimator:
             a=x,
             feat=xax,
             scale=xscale,
-            method=bin_width_doane,
+            method=bin_width_doane_div5,
             ret_scaled=True)
 
         yacc_sc, ys = self.get_spacing(
             a=y,
             feat=yax,
             scale=yscale,
-            method=bin_width_doane,
+            method=bin_width_doane_div5,
             ret_scaled=True)
 
         if xacc is None or xacc == 0:
-            xacc = xacc_sc / 5
+            xacc = xacc_sc
 
         if yacc is None or yacc == 0:
-            yacc = yacc_sc / 5
+            yacc = yacc_sc
 
         # Ignore infs and nans
         bad = get_bad_vals(xs, ys)

--- a/dclab/kde/methods.py
+++ b/dclab/kde/methods.py
@@ -56,6 +56,16 @@ def bin_width_doane(a):
     return acc
 
 
+def bin_width_doane_div5(a):
+    """Compute contour spacing based on Doane's formula divided by five
+
+    See Also
+    --------
+    bin_width_doane: method used to compute the bin width
+    """
+    return bin_width_doane(a) / 5
+
+
 def bin_width_percentile(a):
     """Compute contour spacing based on data percentiles
 

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -69,7 +69,7 @@ Frequently, data is visualized on logarithmic scales. If the KDE
 is computed on a linear scale, then the result will look unaesthetic
 when plotted on a logarithmic scale. Therefore, the methods
 :func:`get_downsampled_scatter <dclab.rtdc_dataset.RTDCBase.get_downsampled_scatter>`,
-:py:meth:`~dclab.kde.KernelDensityEstimator.get_contour`, and
+:py:meth:`~dclab.kde.KernelDensityEstimator.get_raster`, and
 :py:meth:`~dclab.kde.KernelDensityEstimator.get_scatter`
 offer the keyword arguments ``xscale`` and ``yscale`` which can be set to
 "log" for prettier plots.
@@ -142,7 +142,7 @@ Contour plot with percentiles
 Contour plots are commonly used to compare the kernel density
 between measurements. Kernel density estimates (on a grid) for contour
 plots can be computed with the function
-:py:meth:`~dclab.kde.KernelDensityEstimator.get_contour`.
+:py:meth:`~dclab.kde.KernelDensityEstimator.get_raster`.
 In addition, it is possible to compute contours at data
 `percentiles <https://en.wikipedia.org/wiki/Percentile>`_
 using :func:`~dclab.kde.contours.get_quantile_levels`.
@@ -155,7 +155,7 @@ using :func:`~dclab.kde.contours.get_quantile_levels`.
     # load the example dataset
     ds = dclab.new_dataset("data/example.rtdc")
     kde_instance = KernelDensityEstimator(ds)
-    X, Y, Z = kde_instance.get_contour(xax="area_um", yax="deform")
+    X, Y, Z = kde_instance.get_raster(xax="area_um", yax="deform")
     Z /= Z.max()
     quantiles = [.1, .5, .75]
     levels = dclab.kde.contours.get_quantile_levels(density=Z,


### PR DESCRIPTION
This PR aims to deprecate the `get_contour` function with `get_raster` in the KDE class.
- Create `get_raster` method in KDE base.py
- Use `bin_width_doane_div5` instead of `bin_width_doane`
- Replace `get_contour` with `get_raster` in docs