### PR TITLE
Add `get_contour_lines()` method to KernelDensityEstimator 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,10 @@
 0.64.0
- - ref: add `get_contour_lines` method to `KernelDensityEstimator` class
  - feat: introduce concept of perishable (e.g. temporally expiring) basins
  - fix: do not export perishable basins (#254)
  - fix: allow `Basin.verify_basin` to fail
  - fix: `Basin.__repr__` failed when location did not exist
  - setup: drop support for Python 3.8
+ - ref: add `get_contour_lines` method to `KernelDensityEstimator` class
  - ref: deprecate get_contour and use bin_width_doane_div5 in kde submodule
 0.63.1
  - docs: update documentation and code references for kde submodule

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.64.0
+ - ref: add `get_contour_lines` method to `KernelDensityEstimator` class
  - feat: introduce concept of perishable (e.g. temporally expiring) basins
  - fix: do not export perishable basins (#254)
  - fix: allow `Basin.verify_basin` to fail

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -127,8 +127,8 @@ class KernelDensityEstimator:
 
     def get_contour_lines(self, xax="area_um", yax="deform", xacc=None,
                           yacc=None, kde_type="histogram", kde_kwargs=None,
-                          xscale="linear", yscale="linear", ret_levels=False,
-                          quantiles=None):
+                          xscale="linear", yscale="linear", quantiles=None,
+                          ret_levels=False):
         """Compute contour lines for a given kernel kensity estimate.
 
         Parameters
@@ -153,12 +153,13 @@ class KernelDensityEstimator:
             displayed on a log-scale. Defaults to "linear".
         yscale: str
             See `xscale`
+        quantiles: list or array of floats
+            Define the contour levels based on quantiles of the KDE. The
+            values must be between 0 and 1. If set to None, will use
+            [0.5, 0.95] as default.
         ret_levels: bool
             If set to True, return the levels of the contours
             (default: False)
-        quantiles: list or array of floats
-            Define the levels of the contours. The values must be between 0
-            and 1. If set to None, will use [0.5, 0.95] as default.
 
         Returns
         -------
@@ -169,6 +170,7 @@ class KernelDensityEstimator:
             contour line.
         levels: list of floats
             The interpolated density levels for corresponding quantiles levels.
+            Levels are only returned if `ret_levels` is set to True.
         """
         if not quantiles:
             quantiles = [0.5, 0.95]

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -127,7 +127,8 @@ class KernelDensityEstimator:
 
     def get_contour_lines(self, xax="area_um", yax="deform", xacc=None,
                           yacc=None, kde_type="histogram", kde_kwargs=None,
-                          xscale="linear", yscale="linear", quantiles=None):
+                          xscale="linear", yscale="linear", ret_levels=False,
+                          quantiles=None):
         """Compute contour lines for a given kernel kensity estimate.
 
         Parameters
@@ -152,6 +153,9 @@ class KernelDensityEstimator:
             displayed on a log-scale. Defaults to "linear".
         yscale: str
             See `xscale`
+        ret_levels: bool
+            If set to True, return the levels of the contours
+            (default: False)
         quantiles: list or array of floats
             Define the levels of the contours. The values must be between 0
             and 1. If set to None, will use [0.5, 0.95] as default.
@@ -206,7 +210,10 @@ class KernelDensityEstimator:
                 contours.append(cc)
             else:
                 contours.append([])
-        return contours, levels
+        if ret_levels:
+            return contours, levels
+        else:
+            return contours
 
     def get_raster(self, xax="area_um", yax="deform", xacc=None, yacc=None,
                    kde_type="histogram", kde_kwargs=None, xscale="linear",

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -168,9 +168,9 @@ class KernelDensityEstimator:
             corresponding contour lines arrays. Each contour line is a 2D
             array of shape (N, 2), where N is the number of points in the
             contour line.
-        qlev: list of floats
+        levels: list of floats
             The density levels corresponding to quantiles.
-            `qlev` is only returned if `ret_levels` is set to True.
+            `levels` is only returned if `ret_levels` is set to True.
         """
         if not quantiles:
             quantiles = [0.5, 0.95]
@@ -192,7 +192,7 @@ class KernelDensityEstimator:
             warnings.warn("Contour not possible; spacing may be too large!",
                           ContourSpacingTooLarge)
             return []
-        qlev = get_quantile_levels(
+        levels = get_quantile_levels(
             density=density,
             x=x,
             y=y,
@@ -202,18 +202,18 @@ class KernelDensityEstimator:
             normalize=False)
         contours = []
         # Normalize levels to [0, 1]
-        qlevels = np.array(qlev) / density.max()
-        for level in qlevels:
+        nlevels = np.array(levels) / density.max()
+        for nlev in nlevels:
             # make sure that the contour levels are not at the boundaries
-            if not (np.allclose(level, 0, atol=1e-12, rtol=0)
-                    or np.allclose(level, 1, atol=1e-12, rtol=0)):
+            if not (np.allclose(nlev, 0, atol=1e-12, rtol=0)
+                    or np.allclose(nlev, 1, atol=1e-12, rtol=0)):
                 cc = find_contours_level(
-                    density, x=x, y=y, level=level)
+                    density, x=x, y=y, level=nlev)
                 contours.append(cc)
             else:
                 contours.append([])
         if ret_levels:
-            return contours, qlev
+            return contours, levels
         else:
             return contours
 

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -158,10 +158,13 @@ class KernelDensityEstimator:
 
         Returns
         -------
-        contour_lines: list of lists of lists
-            For every qualtile level, this list contains a list of
-            corresponding contour lines. Each line is a list of tuples
-            (x, y) that define the contour line.
+        contour_lines: list of arrays
+            The contour lines for the given quantile levels. Each contour line
+            is a 2D array of shape (N, 2), where N is the number of points in
+            the contour line.
+        qlevels: list of floats
+            The quantile levels for the contour lines. The values are
+            between 0 and 1.
         """
         if not quantiles:
             quantiles = [0.5, 0.95]
@@ -183,7 +186,7 @@ class KernelDensityEstimator:
             warnings.warn("Contour not possible; spacing may be too large!",
                           ContourSpacingTooLarge)
             return []
-        plev = get_quantile_levels(
+        qlevels = get_quantile_levels(
             density=density,
             x=x,
             y=y,
@@ -192,14 +195,14 @@ class KernelDensityEstimator:
             q=np.array(quantiles),
             normalize=True)
         contours = []
-        for level in plev:
+        for level in qlevels:
             # make sure that the contour levels are not at the boundaries
             if not (np.allclose(level, 0, atol=1e-12, rtol=0)
                     or np.allclose(level, 1, atol=1e-12, rtol=0)):
                 cc = find_contours_level(
                     density, x=x, y=y, level=level)
-                contours.append(cc)
-        return contours
+                contours.append(cc[0])
+        return contours, qlevels
 
     def get_raster(self, xax="area_um", yax="deform", xacc=None, yacc=None,
                    kde_type="histogram", kde_kwargs=None, xscale="linear",

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -202,8 +202,8 @@ class KernelDensityEstimator:
             normalize=False)
         contours = []
         # Normalize levels to [0, 1]
-        qlevels = np.array(levels) / density.max()
-        for level in qlevels:
+        qlev = np.array(levels) / density.max()
+        for level in qlev:
             # make sure that the contour levels are not at the boundaries
             if not (np.allclose(level, 0, atol=1e-12, rtol=0)
                     or np.allclose(level, 1, atol=1e-12, rtol=0)):

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -125,14 +125,18 @@ class KernelDensityEstimator:
             xscale=xscale, yscale=yscale
         )
 
-    def get_contour_lines(self, xax="area_um", yax="deform", xacc=None,
-                          yacc=None, kde_type="histogram", kde_kwargs=None,
-                          xscale="linear", yscale="linear", quantiles=None,
+    def get_contour_lines(self, quantiles=None, xax="area_um", yax="deform",
+                          xacc=None, yacc=None, kde_type="histogram",
+                          kde_kwargs=None, xscale="linear", yscale="linear",
                           ret_levels=False):
         """Compute contour lines for a given kernel kensity estimate.
 
         Parameters
         ----------
+        quantiles: list or array of floats
+            Define the contour levels based on quantiles of the KDE. The
+            values must be between 0 and 1. If set to None, will use
+            [0.5, 0.95] as default.
         xax: str
             Identifier for X axis (e.g. "area_um", "aspect", "deform")
         yax: str
@@ -153,10 +157,6 @@ class KernelDensityEstimator:
             displayed on a log-scale. Defaults to "linear".
         yscale: str
             See `xscale`
-        quantiles: list or array of floats
-            Define the contour levels based on quantiles of the KDE. The
-            values must be between 0 and 1. If set to None, will use
-            [0.5, 0.95] as default.
         ret_levels: bool
             If set to True, return the levels of the contours
             (default: False)

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -158,13 +158,14 @@ class KernelDensityEstimator:
 
         Returns
         -------
-        contour_lines: list of arrays
-            The contour lines for the given quantile levels. Each contour line
-            is a 2D array of shape (N, 2), where N is the number of points in
-            the contour line.
-        qlevels: list of floats
-            The quantile levels for the contour lines. The values are
-            between 0 and 1.
+        contour_lines: list of lists of arrays
+            For every qualtile level, this list contains a list of
+            corresponding contour lines arrays. Each contour line is a 2D
+            array of shape (N, 2), where N is the number of points in the
+            contour line.
+        qlevel: list of floats
+            The quantile levels for the contour lines. The values
+            are between 0 and 1.
         """
         if not quantiles:
             quantiles = [0.5, 0.95]
@@ -186,7 +187,7 @@ class KernelDensityEstimator:
             warnings.warn("Contour not possible; spacing may be too large!",
                           ContourSpacingTooLarge)
             return []
-        qlevels = get_quantile_levels(
+        qlevel = get_quantile_levels(
             density=density,
             x=x,
             y=y,
@@ -195,14 +196,14 @@ class KernelDensityEstimator:
             q=np.array(quantiles),
             normalize=True)
         contours = []
-        for level in qlevels:
+        for level in qlevel:
             # make sure that the contour levels are not at the boundaries
             if not (np.allclose(level, 0, atol=1e-12, rtol=0)
                     or np.allclose(level, 1, atol=1e-12, rtol=0)):
                 cc = find_contours_level(
                     density, x=x, y=y, level=level)
-                contours.append(cc[0])
-        return contours, qlevels
+                contours.append(cc)
+        return contours, qlevel
 
     def get_raster(self, xax="area_um", yax="deform", xacc=None, yacc=None,
                    kde_type="histogram", kde_kwargs=None, xscale="linear",

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -168,9 +168,9 @@ class KernelDensityEstimator:
             corresponding contour lines arrays. Each contour line is a 2D
             array of shape (N, 2), where N is the number of points in the
             contour line.
-        levels: list of floats
-            The interpolated density levels for corresponding quantiles levels.
-            Levels are only returned if `ret_levels` is set to True.
+        qlev: list of floats
+            The density levels corresponding to quantiles.
+            `qlev` is only returned if `ret_levels` is set to True.
         """
         if not quantiles:
             quantiles = [0.5, 0.95]
@@ -192,7 +192,7 @@ class KernelDensityEstimator:
             warnings.warn("Contour not possible; spacing may be too large!",
                           ContourSpacingTooLarge)
             return []
-        levels = get_quantile_levels(
+        qlev = get_quantile_levels(
             density=density,
             x=x,
             y=y,
@@ -202,8 +202,8 @@ class KernelDensityEstimator:
             normalize=False)
         contours = []
         # Normalize levels to [0, 1]
-        qlev = np.array(levels) / density.max()
-        for level in qlev:
+        qlevels = np.array(qlev) / density.max()
+        for level in qlevels:
             # make sure that the contour levels are not at the boundaries
             if not (np.allclose(level, 0, atol=1e-12, rtol=0)
                     or np.allclose(level, 1, atol=1e-12, rtol=0)):
@@ -213,7 +213,7 @@ class KernelDensityEstimator:
             else:
                 contours.append([])
         if ret_levels:
-            return contours, levels
+            return contours, qlev
         else:
             return contours
 

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -3,6 +3,11 @@ import warnings
 import numpy as np
 
 from .methods import bin_width_doane_div5, get_bad_vals, methods
+from .contours import find_contours_level, get_quantile_levels
+
+
+class ContourSpacingTooLarge(UserWarning):
+    pass
 
 
 class KernelDensityEstimator:
@@ -119,6 +124,82 @@ class KernelDensityEstimator:
             kde_type=kde_type, kde_kwargs=kde_kwargs,
             xscale=xscale, yscale=yscale
         )
+
+    def get_contour_lines(self, xax="area_um", yax="deform", xacc=None,
+                          yacc=None, kde_type="histogram", kde_kwargs=None,
+                          xscale="linear", yscale="linear", quantiles=None):
+        """Compute contour lines for a given kernel kensity estimate.
+
+        Parameters
+        ----------
+        xax: str
+            Identifier for X axis (e.g. "area_um", "aspect", "deform")
+        yax: str
+            Identifier for Y axis
+        xacc: float
+            Contour accuracy in x direction
+            if set to None, will use :func:`bin_width_doane_div5`
+        yacc: float
+            Contour accuracy in y direction
+            if set to None, will use :func:`bin_width_doane_div5`
+        kde_type: str
+            The KDE method to use
+        kde_kwargs: dict
+            Additional keyword arguments to the KDE method
+        xscale: str
+            If set to "log", take the logarithm of the x-values before
+            computing the KDE. This is useful when data are
+            displayed on a log-scale. Defaults to "linear".
+        yscale: str
+            See `xscale`
+        quantiles: list or array of floats
+            Define the levels of the contours. The values must be between 0
+            and 1. If set to None, will use [0.5, 0.95] as default.
+
+        Returns
+        -------
+        contour_lines: list of lists of lists
+            For every qualtile level, this list contains a list of
+            corresponding contour lines. Each line is a list of tuples
+            (x, y) that define the contour line.
+        """
+        if not quantiles:
+            quantiles = [0.5, 0.95]
+        try:
+            x, y, density = self.get_raster(
+                xax=xax,
+                yax=yax,
+                xacc=xacc,
+                yacc=yacc,
+                xscale=xscale,
+                yscale=yscale,
+                kde_type=kde_type,
+                kde_kwargs=kde_kwargs,
+            )
+        except ValueError:
+            # most-likely there is nothing to compute a contour for
+            return []
+        if density.shape[0] < 3 or density.shape[1] < 3:
+            warnings.warn("Contour not possible; spacing may be too large!",
+                          ContourSpacingTooLarge)
+            return []
+        plev = get_quantile_levels(
+            density=density,
+            x=x,
+            y=y,
+            xp=self.rtdc_ds[xax][self.rtdc_ds.filter.all],
+            yp=self.rtdc_ds[yax][self.rtdc_ds.filter.all],
+            q=np.array(quantiles),
+            normalize=True)
+        contours = []
+        for level in plev:
+            # make sure that the contour levels are not at the boundaries
+            if not (np.allclose(level, 0, atol=1e-12, rtol=0)
+                    or np.allclose(level, 1, atol=1e-12, rtol=0)):
+                cc = find_contours_level(
+                    density, x=x, y=y, level=level)
+                contours.append(cc)
+        return contours
 
     def get_raster(self, xax="area_um", yax="deform", xacc=None, yacc=None,
                    kde_type="histogram", kde_kwargs=None, xscale="linear",

--- a/dclab/rtdc_dataset/feat_basin.py
+++ b/dclab/rtdc_dataset/feat_basin.py
@@ -94,11 +94,17 @@ class PerishableRecord:
         refresh_kwargs: dict
             Additional kwargs for `refresh_func`
         """
-        self.basin = weakref.proxy(basin)
+        if not isinstance(basin, weakref.ProxyType):
+            basin = weakref.proxy(basin)
+        self.basin = basin
         self.expiration_func = expiration_func
         self.expiration_kwargs = expiration_kwargs or {}
         self.refresh_func = refresh_func
         self.refresh_kwargs = refresh_kwargs or {}
+
+    def __repr__(self):
+        state = "perished" if self.perished() else "valid"
+        return f"<PerishableRecord ({state}) at {hex(id(self))}>"
 
     def perished(self) -> Union[bool, None]:
         """Determine whether the basin has perished

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -154,7 +154,6 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
     from dclab.kde import KernelDensityEstimator
     # load the example dataset
     ds = dclab.new_dataset("data/example.rtdc")
-    ds = dclab.new_dataset(p)
     kde_instance = KernelDensityEstimator(ds)
 
     quantiles = [.1, .5, .75]

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -160,6 +160,7 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
 
     contours, levels = kde_instance.get_contour_lines(xax="area_um",
                                                       yax="deform",
+                                                      ret_levels=True,
                                                       quantiles=quantiles)
 
     linestyles = ["--", "--", "-"]

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -137,7 +137,7 @@ Isoelasticity lines are available via the
     plt.show()
 
 
-Contour plot with percentiles
+Contour plot with quantiles
 -----------------------------
 Contour plots are commonly used to compare the kernel density
 between measurements. Kernel density estimates (on a grid) for contour
@@ -145,7 +145,7 @@ plots can be computed with the function
 :py:meth:`~dclab.kde.KernelDensityEstimator.get_raster`.
 In addition, it is possible to compute contours at data
 `percentiles <https://en.wikipedia.org/wiki/Percentile>`_
-using :func:`~dclab.kde.contours.get_quantile_levels`.
+using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
 
 .. plot::
 
@@ -155,35 +155,29 @@ using :func:`~dclab.kde.contours.get_quantile_levels`.
     # load the example dataset
     ds = dclab.new_dataset("data/example.rtdc")
     kde_instance = KernelDensityEstimator(ds)
-    X, Y, Z = kde_instance.get_raster(xax="area_um", yax="deform")
-    Z /= Z.max()
+
     quantiles = [.1, .5, .75]
-    levels = dclab.kde.contours.get_quantile_levels(density=Z,
-                                                    x=X,
-                                                    y=Y,
-                                                    xp=ds["area_um"],
-                                                    yp=ds["deform"],
-                                                    q=quantiles,
-                                                    )
+
+    contours, levels = kde_instance.get_contour_lines(xax="area_um",
+                                                      yax="deform",
+                                                      quantiles=quantiles)
+
+    linestyles = ["--", "--", "-"]
+    colors = ["b", "r", "g"]
 
     ax = plt.subplot(111, title="contour lines")
     sc = ax.scatter(ds["area_um"], ds["deform"], c="lightgray", marker=".", zorder=1)
-    cn = ax.contour(X, Y, Z,
-                    levels=levels,
-                    linestyles=["--", "-", "-"],
-                    colors=["blue", "blue", "darkblue"],
-                    linewidths=[2, 2, 3],
-                    zorder=2)
+
+    for i, (cnt, lvl, qnt) in enumerate(zip(contours, levels, quantiles)):
+        ax.plot(cnt[:, 0], cnt[:, 1],
+                linestyle=linestyles[i],
+                color=colors[i],
+                linewidth=2,
+                label=f"{qnt*100:.0f}th quantile")
 
     ax.set_xlabel(dclab.dfn.get_feature_label("area_um"))
     ax.set_ylabel(dclab.dfn.get_feature_label("deform"))
-    ax.set_xlim(0, 150)
-    ax.set_ylim(0.01, 0.12)
-    # label contour lines with percentiles
-    fmt = {}
-    for l, q in zip(levels, quantiles):
-        fmt[l] = "{:.0f}th".format(q*100)
-    plt.clabel(cn, fmt=fmt)
+    ax.legend()
     plt.show()
 
 Note that you may compute (and plot) the contour lines directly

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -168,12 +168,12 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
     ax = plt.subplot(111, title="contour lines")
     sc = ax.scatter(ds["area_um"], ds["deform"], c="lightgray", marker=".", zorder=1)
 
-    for i, (cnt, lvl, qnt) in enumerate(zip(contours, levels, quantiles)):
-        ax.plot(cnt[:, 0], cnt[:, 1],
+    for i, (cnt, lvl) in enumerate(zip(contours, levels)):
+        ax.plot(cnt[0][:, 0], cnt[0][:, 1],
                 linestyle=linestyles[i],
                 color=colors[i],
                 linewidth=2,
-                label=f"{qnt*100:.0f}th quantile")
+                label=f"{quantiles[i]*100:.0f}th quantile")
 
     ax.set_xlabel(dclab.dfn.get_feature_label("area_um"))
     ax.set_ylabel(dclab.dfn.get_feature_label("deform"))

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -155,33 +155,33 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
     # load the example dataset
     ds = dclab.new_dataset("data/example.rtdc")
     ds = dclab.new_dataset(p)
-kde_instance = KernelDensityEstimator(ds)
+    kde_instance = KernelDensityEstimator(ds)
 
-quantiles = [.1, .5, .75]
+    quantiles = [.1, .5, .75]
 
-contours, levels = kde_instance.get_contour_lines(xax="area_um",
-                                                  yax="deform",
-                                                  quantiles=quantiles)
+    contours, levels = kde_instance.get_contour_lines(xax="area_um",
+                                                    yax="deform",
+                                                    quantiles=quantiles)
 
-linestyles = ["--", "--", "-"]
-colors = ["b", "r", "g"]
+    linestyles = ["--", "--", "-"]
+    colors = ["b", "r", "g"]
 
-ax = plt.subplot(111, title="contour lines")
-sc = ax.scatter(ds["area_um"], ds["deform"], c="lightgray", marker=".", zorder=1)
+    ax = plt.subplot(111, title="contour lines")
+    sc = ax.scatter(ds["area_um"], ds["deform"], c="lightgray", marker=".", zorder=1)
 
-for i, (cnt, lvl, qnt) in enumerate(zip(contours, levels, quantiles)):
-    ax.plot(cnt[:, 0], cnt[:, 1],
-            linestyle=linestyles[i],
-            color=colors[i],
-            linewidth=2,
-            label=f"{qnt*100:.0f}th quantile")
+    for i, (cnt, lvl, qnt) in enumerate(zip(contours, levels, quantiles)):
+        ax.plot(cnt[:, 0], cnt[:, 1],
+                linestyle=linestyles[i],
+                color=colors[i],
+                linewidth=2,
+                label=f"{qnt*100:.0f}th quantile")
 
-ax.set_xlabel(dclab.dfn.get_feature_label("area_um"))
-ax.set_ylabel(dclab.dfn.get_feature_label("deform"))
-ax.set_xlim(0, 160)
-ax.set_ylim(0, 0.09)
-ax.legend()
-plt.show()
+    ax.set_xlabel(dclab.dfn.get_feature_label("area_um"))
+    ax.set_ylabel(dclab.dfn.get_feature_label("deform"))
+    ax.set_xlim(0, 160)
+    ax.set_ylim(0, 0.09)
+    ax.legend()
+    plt.show()
 
 Note that you may compute (and plot) the contour lines directly
 yourself using the function :func:`~dclab.kde.contours.find_contours_level`.

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -154,31 +154,34 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
     from dclab.kde import KernelDensityEstimator
     # load the example dataset
     ds = dclab.new_dataset("data/example.rtdc")
-    kde_instance = KernelDensityEstimator(ds)
+    ds = dclab.new_dataset(p)
+kde_instance = KernelDensityEstimator(ds)
 
-    quantiles = [.1, .5, .75]
+quantiles = [.1, .5, .75]
 
-    contours, levels = kde_instance.get_contour_lines(xax="area_um",
-                                                      yax="deform",
-                                                      quantiles=quantiles)
+contours, levels = kde_instance.get_contour_lines(xax="area_um",
+                                                  yax="deform",
+                                                  quantiles=quantiles)
 
-    linestyles = ["--", "--", "-"]
-    colors = ["b", "r", "g"]
+linestyles = ["--", "--", "-"]
+colors = ["b", "r", "g"]
 
-    ax = plt.subplot(111, title="contour lines")
-    sc = ax.scatter(ds["area_um"], ds["deform"], c="lightgray", marker=".", zorder=1)
+ax = plt.subplot(111, title="contour lines")
+sc = ax.scatter(ds["area_um"], ds["deform"], c="lightgray", marker=".", zorder=1)
 
-    for i, (cnt, lvl, qnt) in enumerate(zip(contours, levels, quantiles)):
-        ax.plot(cnt[:, 0], cnt[:, 1],
-                linestyle=linestyles[i],
-                color=colors[i],
-                linewidth=2,
-                label=f"{qnt*100:.0f}th quantile")
+for i, (cnt, lvl, qnt) in enumerate(zip(contours, levels, quantiles)):
+    ax.plot(cnt[:, 0], cnt[:, 1],
+            linestyle=linestyles[i],
+            color=colors[i],
+            linewidth=2,
+            label=f"{qnt*100:.0f}th quantile")
 
-    ax.set_xlabel(dclab.dfn.get_feature_label("area_um"))
-    ax.set_ylabel(dclab.dfn.get_feature_label("deform"))
-    ax.legend()
-    plt.show()
+ax.set_xlabel(dclab.dfn.get_feature_label("area_um"))
+ax.set_ylabel(dclab.dfn.get_feature_label("deform"))
+ax.set_xlim(0, 160)
+ax.set_ylim(0, 0.09)
+ax.legend()
+plt.show()
 
 Note that you may compute (and plot) the contour lines directly
 yourself using the function :func:`~dclab.kde.contours.find_contours_level`.

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -159,8 +159,8 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
     quantiles = [.1, .5, .75]
 
     contours, levels = kde_instance.get_contour_lines(xax="area_um",
-                                                    yax="deform",
-                                                    quantiles=quantiles)
+                                                      yax="deform",
+                                                      quantiles=quantiles)
 
     linestyles = ["--", "--", "-"]
     colors = ["b", "r", "g"]

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -137,7 +137,7 @@ Isoelasticity lines are available via the
     plt.show()
 
 
-Contour plot with quantiles
+Contour plot with percentiles
 -----------------------------
 Contour plots are commonly used to compare the kernel density
 between measurements. Kernel density estimates (on a grid) for contour

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -170,7 +170,8 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
     sc = ax.scatter(ds["area_um"], ds["deform"], c="lightgray", marker=".", zorder=1)
 
     for i, (cnt, lvl) in enumerate(zip(contours, levels)):
-        ax.plot(cnt[0][:, 0], cnt[0][:, 1],
+        for c in cnt:
+            ax.plot(c[:, 0], c[:, 1],
                 linestyle=linestyles[i],
                 color=colors[i],
                 linewidth=2,

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -160,8 +160,8 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
 
     contours, levels = kde_instance.get_contour_lines(xax="area_um",
                                                       yax="deform",
-                                                      ret_levels=True,
-                                                      quantiles=quantiles)
+                                                      quantiles=quantiles,
+                                                      ret_levels=True,)
 
     linestyles = ["--", "--", "-"]
     colors = ["b", "r", "g"]

--- a/docs/sec_av_scatter.rst
+++ b/docs/sec_av_scatter.rst
@@ -158,9 +158,9 @@ using :func:`~dclab.kde.KernelDensityEstimator.get_contour_lines`.
 
     quantiles = [.1, .5, .75]
 
-    contours, levels = kde_instance.get_contour_lines(xax="area_um",
+    contours, levels = kde_instance.get_contour_lines(quantiles=quantiles,
+                                                      xax="area_um",
                                                       yax="deform",
-                                                      quantiles=quantiles,
                                                       ret_levels=True,)
 
     linestyles = ["--", "--", "-"]

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -15,15 +15,15 @@ def test_contour_lines():
 
     kde_instance = KernelDensityEstimator(ds)
 
-    contours, levels = kde_instance.get_contour_lines(xax="area_um",
-                                                      yax="deform",
-                                                      xacc=.10,
-                                                      yacc=.01,
-                                                      kde_type="histogram",
-                                                      kde_kwargs=None,
-                                                      xscale="linear",
-                                                      yscale="linear",
-                                                      quantiles=[0.89])
+    contours = kde_instance.get_contour_lines(xax="area_um",
+                                              yax="deform",
+                                              xacc=.10,
+                                              yacc=.01,
+                                              kde_type="histogram",
+                                              kde_kwargs=None,
+                                              xscale="linear",
+                                              yscale="linear",
+                                              quantiles=[0.89])
     nump = 0
     for p in zip(x0, y0):
         nump += polygon_filter.PolygonFilter.point_in_poly(p,

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -36,3 +36,38 @@ def test_contour_lines():
         np.concatenate((x0.reshape(-1, 1), y0.reshape(-1, 1)), axis=1),
         contours[0][0])
     assert nump2.sum() == 11
+
+
+def test_contour_lines_without_quantiles_with_ret_levels():
+    np.random.seed(47)
+    x0 = np.random.normal(loc=100, scale=10, size=100)
+    y0 = np.random.normal(loc=.1, scale=.01, size=100)
+
+    ds = dclab.new_dataset({"area_um": x0, "deform": y0})
+    ds.config["filtering"]["enable filters"] = False
+
+    kde_instance = KernelDensityEstimator(ds)
+
+    contours, levels = kde_instance.get_contour_lines(xax="area_um",
+                                                      yax="deform",
+                                                      xacc=.10,
+                                                      yacc=.01,
+                                                      kde_type="histogram",
+                                                      kde_kwargs=None,
+                                                      xscale="linear",
+                                                      yscale="linear",
+                                                      ret_levels=True,)
+    nump = 0
+    for p in zip(x0, y0):
+        nump += polygon_filter.PolygonFilter.point_in_poly(p,
+                                                           poly=contours[0][1])
+
+    assert nump == 50, "there should be (1-q)*100 points in the contour"
+
+    # added in dclab 0.24.1
+    nump2 = skimage.measure.points_in_poly(
+        np.concatenate((x0.reshape(-1, 1), y0.reshape(-1, 1)), axis=1),
+        contours[0][1])
+    assert nump2.sum() == 50
+
+    assert len(levels) == 2, "there should be two levels"

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -15,24 +15,23 @@ def test_contour_lines():
 
     kde_instance = KernelDensityEstimator(ds)
 
-    contours = kde_instance.get_contour_lines(xax="area_um",
-                                              yax="deform",
-                                              xacc=.10,
-                                              yacc=.01,
-                                              kde_type="histogram",
-                                              kde_kwargs=None,
-                                              xscale="linear",
-                                              yscale="linear",
-                                              quantiles=[0.89])
+    contours, levels = kde_instance.get_contour_lines(xax="area_um",
+                                                      yax="deform",
+                                                      xacc=.10,
+                                                      yacc=.01,
+                                                      kde_type="histogram",
+                                                      kde_kwargs=None,
+                                                      xscale="linear",
+                                                      yscale="linear",
+                                                      quantiles=[0.89])
     nump = 0
     for p in zip(x0, y0):
-        nump += polygon_filter.PolygonFilter.point_in_poly(p,
-                                                           poly=contours[0][0])
+        nump += polygon_filter.PolygonFilter.point_in_poly(p, poly=contours[0])
 
     assert nump == 11, "there should be (1-q)*100 points in the contour"
 
     # added in dclab 0.24.1
     nump2 = skimage.measure.points_in_poly(
         np.concatenate((x0.reshape(-1, 1), y0.reshape(-1, 1)), axis=1),
-        contours[0][0])
+        contours[0])
     assert nump2.sum() == 11

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -26,12 +26,13 @@ def test_contour_lines():
                                                       quantiles=[0.89])
     nump = 0
     for p in zip(x0, y0):
-        nump += polygon_filter.PolygonFilter.point_in_poly(p, poly=contours[0])
+        nump += polygon_filter.PolygonFilter.point_in_poly(p,
+                                                           poly=contours[0][0])
 
     assert nump == 11, "there should be (1-q)*100 points in the contour"
 
     # added in dclab 0.24.1
     nump2 = skimage.measure.points_in_poly(
         np.concatenate((x0.reshape(-1, 1), y0.reshape(-1, 1)), axis=1),
-        contours[0])
+        contours[0][0])
     assert nump2.sum() == 11

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import dclab
 from dclab.external import skimage
 from dclab.kde import KernelDensityEstimator
@@ -71,3 +72,30 @@ def test_contour_lines_without_quantiles_with_ret_levels():
     assert nump2.sum() == 50
 
     assert len(levels) == 2, "there should be two levels"
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning", "ignore::RuntimeWarning")
+def test_contour_lines_data_with_too_much_space():
+    np.random.seed(47)
+    x0 = np.random.normal(loc=100, scale=10, size=100)
+    y0 = np.random.normal(loc=.1, scale=.01, size=100)
+
+    n = 100  # Adjust this to control spacing
+    x0 = x0[::n]
+    y0 = y0[::n]
+
+    ds = dclab.new_dataset({"area_um": x0, "deform": y0})
+    ds.config["filtering"]["enable filters"] = False
+
+    kde_instance = KernelDensityEstimator(ds)
+
+    contours = kde_instance.get_contour_lines(xax="area_um",
+                                              yax="deform",
+                                              xacc=.10,
+                                              yacc=.01,
+                                              kde_type="histogram",
+                                              kde_kwargs=None,
+                                              xscale="linear",
+                                              yscale="linear",
+                                              quantiles=[0.5])
+    assert not contours, "there should be no contours with too much space"

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -1,0 +1,38 @@
+import numpy as np
+import dclab
+from dclab.external import skimage
+from dclab.kde import KernelDensityEstimator
+from dclab import polygon_filter
+
+
+def test_contour_lines():
+    np.random.seed(47)
+    x0 = np.random.normal(loc=100, scale=10, size=100)
+    y0 = np.random.normal(loc=.1, scale=.01, size=100)
+
+    ds = dclab.new_dataset({"area_um": x0, "deform": y0})
+    ds.config["filtering"]["enable filters"] = False
+
+    kde_instance = KernelDensityEstimator(ds)
+
+    contours = kde_instance.get_contour_lines(xax="area_um",
+                                              yax="deform",
+                                              xacc=.10,
+                                              yacc=.01,
+                                              kde_type="histogram",
+                                              kde_kwargs=None,
+                                              xscale="linear",
+                                              yscale="linear",
+                                              quantiles=[0.89])
+    nump = 0
+    for p in zip(x0, y0):
+        nump += polygon_filter.PolygonFilter.point_in_poly(p,
+                                                           poly=contours[0][0])
+
+    assert nump == 11, "there should be (1-q)*100 points in the contour"
+
+    # added in dclab 0.24.1
+    nump2 = skimage.measure.points_in_poly(
+        np.concatenate((x0.reshape(-1, 1), y0.reshape(-1, 1)), axis=1),
+        contours[0][0])
+    assert nump2.sum() == 11


### PR DESCRIPTION
This PR aims to add the `get_contour_lines()` method to the `KernelDensityEstimator` class. This method simplifies the contour computation by combining the `get_raster()` and `get_quantile_levels()` methods.

- [x] Add new method `get_contour_lines()` 
- [x] Update test function/s
- [x] Update corresponding docs
- [x] Update changelog
- [x] Passed CICD