### PR TITLE
Use raster based interpolation method to speedup density calculation in get_scatter

### DIFF
--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -444,7 +444,8 @@ class KernelDensityEstimator:
             interp_func = RGI((xrs[:, 0], yrs[0, :]),
                               density_grid,
                               method="linear",
-                              bounds_error=False)
+                              bounds_error=False,
+                              fill_value=np.nan)
             density = interp_func((xs, ys))
 
         else:

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -376,8 +376,9 @@ class KernelDensityEstimator:
 
         return density
 
-    def get_events(self, xax="area_um", yax="deform", kde_type="histogram",
-                   kde_kwargs=None, xscale="linear", yscale="linear"):
+    def get_at(self, xax="area_um", yax="deform", positions=None,
+               kde_type="histogram", kde_kwargs=None, xscale="linear",
+               yscale="linear"):
         """Evaluate the kernel density estimate for events
 
         Parameters
@@ -386,6 +387,10 @@ class KernelDensityEstimator:
             Identifier for X axis (e.g. "area_um", "aspect", "deform")
         yax: str
             Identifier for Y axis
+        positions: list of two 1d ndarrays or ndarray of shape (2, N)
+            The positions where the KDE will be computed. Note that
+            the KDE estimate is computed from the points that
+            are set in `self.rtdc_ds.filter.all`.
         kde_type: str
             The KDE method to use, see :const:`.kde_methods.methods`
         kde_kwargs: dict
@@ -418,6 +423,10 @@ class KernelDensityEstimator:
         xs = self.apply_scale(x, xscale, xax)
         ys = self.apply_scale(y, yscale, yax)
 
+        if positions:
+            xs = self.apply_scale(positions[0], xscale, xax)
+            ys = self.apply_scale(positions[1], yscale, yax)
+
         if len(x):
             xr, yr, density_grid = self.get_raster(xax=xax,
                                                    yax=yax,
@@ -437,6 +446,7 @@ class KernelDensityEstimator:
                               method="linear",
                               bounds_error=False)
             density = interp_func((xs, ys))
+
         else:
             density = np.array([])
 

--- a/dclab/kde/base.py
+++ b/dclab/kde/base.py
@@ -359,22 +359,20 @@ class KernelDensityEstimator:
         xs = self.apply_scale(x, xscale, xax)
         ys = self.apply_scale(y, yscale, yax)
 
-        xr, yr, density_grid = self.get_raster(
-            xax=xax,
-            yax=yax,
-            kde_type=kde_type,
-            kde_kwargs=kde_kwargs,
-            xscale=xscale,
-            yscale=yscale
-        )
-        # 'scipy.interp2d' has been removed in SciPy 1.14.0
-        # https://scipy.github.io/devdocs/tutorial/interpolate/interp_transition_guide.html
-        interp_func = RGI((xr[:, 0], yr[0, :]),
-                          density_grid,
-                          method='linear',
-                          bounds_error=True,
-                          fill_value=0)
         if len(x):
+            xr, yr, density_grid = self.get_raster(xax=xax,
+                                                   yax=yax,
+                                                   kde_type=kde_type,
+                                                   kde_kwargs=kde_kwargs,
+                                                   xscale=xscale,
+                                                   yscale=yscale)
+            # 'scipy.interp2d' has been removed in SciPy 1.14.0
+            # https://scipy.github.io/devdocs/tutorial/interpolate/interp_transition_guide.html
+            interp_func = RGI((xr[:, 0], yr[0, :]),
+                              density_grid,
+                              method='linear',
+                              bounds_error=False,
+                              fill_value=0)
             density = interp_func((xs, ys))
         else:
             density = np.array([])

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -103,27 +103,27 @@ def test_contour_lines_data_with_too_much_space():
     assert not contours, "there should be no contours with too much space"
 
 
-def test_kde_log_events():
+def test_kde_log_get_at():
     ddict = example_data_dict(size=300, keys=["area_um", "deform"])
     ddict["deform"][:20] = .1
     ddict["area_um"][:20] = .5
     ds = dclab.new_dataset(ddict)
     kde_instance = KernelDensityEstimator(ds)
-    a = kde_instance.get_events(xax="area_um", yax="deform", yscale="log")
+    a = kde_instance.get_at(xax="area_um", yax="deform", yscale="log")
     assert np.all(a[:20] == a[0])
 
 
-def test_kde_log_event_points():
+def test_kde_log_get_at_points():
     ddict = example_data_dict(size=300, keys=["area_um", "tilt"])
     ds = dclab.new_dataset(ddict)
     kde_instance = KernelDensityEstimator(ds)
-    a = kde_instance.get_events(yscale="log", xax="area_um", yax="tilt")
-    b = kde_instance.get_events(yscale="log", xax="area_um", yax="tilt")
+    a = kde_instance.get_at(yscale="log", xax="area_um", yax="tilt")
+    b = kde_instance.get_at(yscale="log", xax="area_um", yax="tilt")
 
     assert np.all(a == b)
 
 
-def test_kde_log_events_invalid():
+def test_kde_log_get_at_invalid():
     ddict = example_data_dict(size=300, keys=["area_um", "deform"])
     ddict["deform"][:20] = .1
     ddict["area_um"][:20] = .5
@@ -132,8 +132,21 @@ def test_kde_log_events_invalid():
     ddict["deform"][23] = -.1
     ds = dclab.new_dataset(ddict)
     kde_instance = KernelDensityEstimator(ds)
-    a = kde_instance.get_events(xax="area_um", yax="deform", yscale="log")
+    a = kde_instance.get_at(xax="area_um", yax="deform", yscale="log")
     assert np.all(a[:20] == a[0])
     assert np.isnan(a[21])
     assert np.isnan(a[22])
     assert np.isnan(a[23])
+
+
+def test_kde_get_at_positions():
+    ddict = example_data_dict()
+    ds = dclab.new_dataset(ddict)
+
+    kde_instance = KernelDensityEstimator(ds)
+
+    ds.config["filtering"]["enable filters"] = False
+    sc = kde_instance.get_at(xax="area_um", yax="deform")
+    sc2 = kde_instance.get_at(xax="area_um", yax="deform",
+                              positions=(ds["area_um"], ds["deform"]))
+    assert np.all(sc == sc2)

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -150,3 +150,22 @@ def test_kde_get_at_positions():
     sc2 = kde_instance.get_at(xax="area_um", yax="deform",
                               positions=(ds["area_um"], ds["deform"]))
     assert np.all(sc == sc2)
+
+
+def test_kde_log_get_at_out_of_bounds():
+    ddict = example_data_dict(size=300, keys=["area_um", "deform"])
+    ds = dclab.new_dataset(ddict)
+    kde_instance = KernelDensityEstimator(ds)
+
+    # Define a positions that has values outside the typical data range
+    # `area_um` ([0.0, 400]) and `deform` ([0.0, 0.02])
+    positions = ([410, 300, 300, 300],
+                 [-1, -2, 0.01, 0.015])
+
+    # Get the density at the out-of-bounds position
+    a = kde_instance.get_at(xax="area_um", yax="deform",
+                            positions=positions, yscale="log")
+    assert np.isnan(a[0])
+    assert np.isnan(a[1])
+    assert np.isfinite(a[2])
+    assert np.isfinite(a[3])

--- a/tests/test_rtdc_kde.py
+++ b/tests/test_rtdc_kde.py
@@ -81,7 +81,7 @@ def test_kde_log_scatter_invalid():
     a = ds.get_kde_scatter(yscale="log")
     assert np.all(a[:20] == a[0])
     assert np.isnan(a[21])
-    assert np.isnan(a[22])
+    assert np.isfinite(a[22])
     assert np.isnan(a[23])
 
 

--- a/tests/test_rtdc_kde.py
+++ b/tests/test_rtdc_kde.py
@@ -81,7 +81,7 @@ def test_kde_log_scatter_invalid():
     a = ds.get_kde_scatter(yscale="log")
     assert np.all(a[:20] == a[0])
     assert np.isnan(a[21])
-    assert np.isfinite(a[22])
+    assert np.isnan(a[22])
     assert np.isnan(a[23])
 
 


### PR DESCRIPTION
This PR aims to implement the `get_events()` method in the KDE base module as an alternative to the `get_scatter()` method. This `get_events()` method uses a raster-based `scipy.RegularGridInterpolator` method to calculate the density, which is ~2 times faster than the available `kde_methods`. This is described in issue #153.

## Benchmarking:
```
# dataset: https://dcor.mpl.mpg.de/dataset/naiad-reference-data/resource/8d8a1b47-f24a-4d91-85f6-0160dea0226d
```

### Points-based KDE calculation:
```
path_id= "8d8a1b47-f24a-4d91-85f6-0160dea0226d"

import dclab
from dclab.kde import KernelDensityEstimator
import time 

ds = dclab.new_dataset(path_id)

kde_instance = KernelDensityEstimator(ds)

t1 = time.time()
kde = kde_instance.get_scatter(xax="area_um", yax="deform")

print("points based KDE comp time:", time.time()-t1)
```
#### Output:
```
KDE method density comp time: 0.19197535514831543
points based KDE comp time: 2.5030810832977295
```

### Raster-based KDE calculation:
```
path_id= "8d8a1b47-f24a-4d91-85f6-0160dea0226d"

import dclab
from dclab.kde import KernelDensityEstimator
import time 

ds = dclab.new_dataset(path_id)

kde_instance = KernelDensityEstimator(ds)

t1 = time.time()
kde = kde_instance.get_events(xax="area_um", yax="deform")

print("raster based KDE comp time:", time.time()-t2)
```
#### Output:
```
scipy.RegularGridInterpolator density comp time: 0.061484575271606445
raster based KDE comp time: 2.1816139221191406
```


- [x] make relevant code changes
- [ ] CICD passed
- [ ] update CHANGELOG after review