### PR TITLE
Add qpi mass density feature, deprecate incorrect qpi features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.67.1
+ - enh: add mass density feature, deprecate some qpi features (#284)
 0.67.0
  - BREAKING CHANGE: make it difficult to export the "contour" feature
  - fix: `BasinProxyFeature` returned incorrect `shape` and `size`

--- a/dclab/definitions/feat_const.py
+++ b/dclab/definitions/feat_const.py
@@ -91,11 +91,13 @@ FEATURES_SCALAR = [
     # Sum of the pressures applied to sample and sheath flow
     ["pressure", "Pressure [mPa]"],
     # QPI features computed from holographic data
-    ["qpi_dm_avg", "Dry mass (average) [pg]"],
-    ["qpi_dm_sd", "Dry mass (SD) [pg]"],
+    ["qpi_dm", "Dry mass [pg]"],
+    ["qpi_dm_avg", "DEPRECATED Dry mass (average) [pg]"],
+    ["qpi_dm_dns", "Dry mass density [mg/ml]"],
+    ["qpi_ri_sd", "DEPRECATED Refractive index (SD)"],
     ["qpi_pha_int", "Integrated phase [rad]"],
     ["qpi_ri_avg", "Refractive index (average)"],
-    ["qpi_ri_sd", "Refractive index (SD)"],
+    ["qpi_dm_sd", "DEPRECATED Dry mass (SD) [pg]"],
     # QPI features from refocused events
     ["qpi_focus", "Computed focus distance [µm]"],
     # Size features

--- a/dclab/definitions/feat_const.py
+++ b/dclab/definitions/feat_const.py
@@ -94,10 +94,10 @@ FEATURES_SCALAR = [
     ["qpi_dm", "Dry mass [pg]"],
     ["qpi_dm_avg", "DEPRECATED Dry mass (average) [pg]"],
     ["qpi_dm_dns", "Dry mass density [mg/ml]"],
-    ["qpi_ri_sd", "DEPRECATED Refractive index (SD)"],
+    ["qpi_dm_sd", "DEPRECATED Dry mass (SD) [pg]"],
     ["qpi_pha_int", "Integrated phase [rad]"],
     ["qpi_ri_avg", "Refractive index (average)"],
-    ["qpi_dm_sd", "DEPRECATED Dry mass (SD) [pg]"],
+    ["qpi_ri_sd", "DEPRECATED Refractive index (SD)"],
     # QPI features from refocused events
     ["qpi_focus", "Computed focus distance [µm]"],
     # Size features


### PR DESCRIPTION
Adding (dry) mass density feature to list of qpi features. Also deprecating the incorrect qpi features.
See #284 for discussion.